### PR TITLE
Fix arrow key navigation in Firefox

### DIFF
--- a/.changeset/social-frogs-love.md
+++ b/.changeset/social-frogs-love.md
@@ -1,0 +1,7 @@
+---
+"@jsondive/library": patch
+"@jsondive/viewer": patch
+"@jsondive/shared-config": patch
+---
+
+Fix arrow key navigation in Firefox

--- a/packages/library/src/lib/keyboardUtils.ts
+++ b/packages/library/src/lib/keyboardUtils.ts
@@ -40,7 +40,6 @@ const modifierKeyToAlias = {
 	FnLock: true,
 	Hyper: true,
 	Meta: "command",
-	NumLock: true,
 	ScrollLock: true,
 	Shift: "shift",
 	Super: true,

--- a/packages/viewer/src/state/index.tsx
+++ b/packages/viewer/src/state/index.tsx
@@ -300,6 +300,7 @@ function useOnKeyDown(eventBus: AppEventBus) {
 					motionMultiplier.current = undefined
 				}, KEY_MULTIPLIER_DEBOUNCE_MS)
 			} else {
+				// Other keys and non-motion-multipliers.
 				eventBus.emit("keyDown", e, motionMultiplier.current ?? 1)
 				motionMultiplier.current = undefined
 			}

--- a/packages/viewer/src/view/TreeRow/TreeRow.tsx
+++ b/packages/viewer/src/view/TreeRow/TreeRow.tsx
@@ -186,7 +186,6 @@ export function TreeRow(props: TreeRowProps) {
 		isRoot,
 		intersectionObserver,
 	} = props
-	console.log("TreeRow render")
 
 	const displayInfo = nodeDisplayMap.get(node)
 	if (!displayInfo) {
@@ -425,10 +424,8 @@ function useManageIntersectionObserver(args: {
 	useEffect(() => {
 		const el = containerRef.current
 		if (el && intersectionObserver) {
-			console.log("observing..")
 			intersectionObserver.observe(el)
 			return () => {
-				console.log("unobserving")
 				intersectionObserver.unobserve(el)
 				setNodeVisibility([
 					{


### PR DESCRIPTION
Firefox passed NumLock as a modifier key where Chrome did not. Just remove NumLock from the modifier key map because I don't care about it.